### PR TITLE
Add Debayring toggle - Also stores/restores DebayerdHRF and UnlinkedStretch values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# FasterFlats
 
+## 1.0.0.3 - 04.02.26
+- Added option to toggle Debayering. Since "Debayered HRF" and "Unlinked Stretch" settings depend on Debayering, their value is stored if disabling Debayering and restored to the last state when toggled back on. (As long as NINA is not closed their state is remembered)
+
 ## 1.0.0.2 - 14.11.25
 - Fix serialization instruction to/from targets/template
 

--- a/FasterflatsSequenceItems/FasterflatsInstruction.cs
+++ b/FasterflatsSequenceItems/FasterflatsInstruction.cs
@@ -81,6 +81,9 @@ namespace NaixxGithub.NINA.Fasterflats.FasterflatsTestCategory {
             AnnotateImage = copyMe.AnnotateImage;
             DetectStars = copyMe.DetectStars;
             AutoStretch = copyMe.AutoStretch;
+            Debayering = copyMe.Debayering;
+            savedDebayeredHFR = copyMe.savedDebayeredHFR;
+            savedUnlinkedStretch = copyMe.savedUnlinkedStretch;
         }
 
         private bool? _annotateImage;
@@ -120,6 +123,19 @@ namespace NaixxGithub.NINA.Fasterflats.FasterflatsTestCategory {
             }
         }
 
+        private bool? debayering;
+        private bool? savedDebayeredHFR;
+        private bool? savedUnlinkedStretch;
+
+        [JsonProperty]
+        public bool? Debayering {
+            get => debayering;
+            set {
+                debayering = value;
+                OnPropertyChanged(); 
+            }
+        }
+
         /// <summary>
         /// The core logic when the sequence item is running resides here
         /// Add whatever action is necessary
@@ -133,6 +149,23 @@ namespace NaixxGithub.NINA.Fasterflats.FasterflatsTestCategory {
             imageSettings.AnnotateImage = AnnotateImage ?? imageSettings.AnnotateImage;
             imageControlVm.AutoStretch = AutoStretch ?? imageControlVm.AutoStretch;
             imageControlVm.DetectStars = DetectStars ?? imageControlVm.DetectStars;
+
+            // Handle Debayering with state restoration
+            if (Debayering.HasValue) {
+                if (Debayering == false) {
+                    // Disable debayering: store current states and set to false
+                    savedDebayeredHFR = imageSettings.DebayeredHFR;
+                    savedUnlinkedStretch = imageSettings.UnlinkedStretch;
+                    imageSettings.DebayerImage = false;
+                    imageSettings.DebayeredHFR = false;
+                    imageSettings.UnlinkedStretch = false;
+                } else if (Debayering == true) {
+                    // Enable debayering: restore saved states or use defaults
+                    imageSettings.DebayerImage = true;
+                    imageSettings.DebayeredHFR = savedDebayeredHFR ?? true;
+                    imageSettings.UnlinkedStretch = savedUnlinkedStretch ?? true;
+                }
+            }
 
             // Add logic to run the item here
             return Task.CompletedTask;

--- a/FasterflatsSequenceItems/FasterflatsTemplates.xaml
+++ b/FasterflatsSequenceItems/FasterflatsTemplates.xaml
@@ -172,6 +172,15 @@
 
                         IsChecked="{Binding DetectStars}" />
 
+                    <TextBlock VerticalAlignment="Center" Text="Debayering:" />
+                    <CheckBox
+                        Style="{StaticResource TriStateCheckBox}"
+                        MinWidth="120"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+
+                        IsChecked="{Binding Debayering}" />
+
 
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemContent>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyFileVersion("1.0.0.3")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("FasterFlats")]


### PR DESCRIPTION
Hi! Instead of bothering you with implementing a switch to disable Debayering as an option, I decided to just spend some time and try to do this myself and effectively contribute to this project.

I implemented the checkbox with the same logic the other options were implemented. Its either do not change/on/off.

In case of debayering its has 2 other options in imaging settings that depend on it. Debayered HRF and Unlinked Stretch. Those change automatically in the UI if Debayering is changed. Hence I implemented it the following way:

- When setting "Debayering" to OFF in the sequencer, the current state for Debayered HRF and Unlinked stretch are stored
- Debayering is then turned off
- Once Debayering is enabled again via the Plugin in the sequencer, the values are restored properly.
- The values are not cached across restarts of NINA

I have tested this in dry-runs as well as with a proper flat and flat dark sequence. So far, it works as expected. I tried it with auto brightness flat wizard sequence item and that worked without issues even if debayering is turned off. 

Thx for considering the merge. 

Best,
Matthias